### PR TITLE
chore: update master refs to main in workflows and docs

### DIFF
--- a/docker-pull-tag-push/README.md
+++ b/docker-pull-tag-push/README.md
@@ -29,7 +29,7 @@ jobs:
         run: az acr login --name ${{ vars.AZ_ACR_NAME }}
 
       - name: Pull, tag, and push Docker image
-        uses: ProductDNA-CH/github-actions/docker-pull-tag-push@master
+        uses: ProductDNA-CH/github-actions/docker-pull-tag-push@main
         with:
           registry: ${{ secrets.REGISTRY_URL }}
           image_name: myimage

--- a/get-branches-to-rebase/README.md
+++ b/get-branches-to-rebase/README.md
@@ -40,7 +40,7 @@ Add the following step to your workflow:
 ```yaml
 - name: Get branches to rebase  
   id: get-branches  
-  uses: ProductDNA-CH/github-actions/get-branches-to-rebase@master
+  uses: ProductDNA-CH/github-actions/get-branches-to-rebase@main
 ```
 
 You can then access the output as a JSON array:

--- a/gist-lock/README.md
+++ b/gist-lock/README.md
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Create Gist lock
         id: create
-        uses: ProductDNA-CH/github-actions/gist-lock@master
+        uses: ProductDNA-CH/github-actions/gist-lock@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           mode: create
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Acquire lock
-        uses: ProductDNA-CH/github-actions/gist-lock@master
+        uses: ProductDNA-CH/github-actions/gist-lock@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           gist-id: ${{ needs.setup-lock.outputs.gist-id }}
@@ -53,7 +53,7 @@ jobs:
         run: echo "🚧 Critical work in progress..."
 
       - name: Release lock
-        uses: ProductDNA-CH/github-actions/gist-lock@master
+        uses: ProductDNA-CH/github-actions/gist-lock@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           gist-id: ${{ needs.setup-lock.outputs.gist-id }}
@@ -65,7 +65,7 @@ jobs:
     if: always()
     steps:
       - name: Delete Gist
-        uses: ProductDNA-CH/github-actions/gist-lock@master
+        uses: ProductDNA-CH/github-actions/gist-lock@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           gist-id: ${{ needs.setup-lock.outputs.gist-id }}

--- a/install-argocd-cli/README.md
+++ b/install-argocd-cli/README.md
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ArgoCD CLI install
-        uses: ProductDNA-CH/github-actions/install-argocd-cli@master
+        uses: ProductDNA-CH/github-actions/install-argocd-cli@main
       - name: ArgoCD Applications deploy
         run: |
           argocd app set myapp --helm-set image.tag=${{ github.event.inputs.tag }}

--- a/install-kubectl/README.md
+++ b/install-kubectl/README.md
@@ -12,7 +12,7 @@ This action installs the [kubectl](https://kubernetes.io/docs/tasks/tools/) CLI 
 
 ```yaml
 - name: Install kubectl
-  uses: ProductDNA-CH/github-actions/install-kubectl@master
+  uses: ProductDNA-CH/github-actions/install-kubectl@main
   with:
     version: 'latest' # or specify a version, e.g., '1.29.0'
 ```
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install kubectl
-        uses: ProductDNA-CH/github-actions/install-kubectl@master
+        uses: ProductDNA-CH/github-actions/install-kubectl@main
         with:
           version: 'latest'
       - name: Verify kubectl version

--- a/terraform-init/README.md
+++ b/terraform-init/README.md
@@ -28,7 +28,7 @@ jobs:
 
       - name: Terraform init
         id: init
-        uses: ProductDNA-CH/github-actions/terraform-init@master
+        uses: ProductDNA-CH/github-actions/terraform-init@main
         with:
           storage-account-name: ${{ vars.AZ_TF_STORAGE_ACCOUNT_NAME }}
           container-name: ${{ vars.AZ_TF_CONTAINER_NAME }}

--- a/validate-branch-name-on-pr/README.md
+++ b/validate-branch-name-on-pr/README.md
@@ -32,7 +32,7 @@ Add the following step to your workflow:
 
 ```yaml
 - name: Validate branch name
-  uses: ProductDNA-CH/github-actions/validate-branch-name-on-pr@master
+  uses: ProductDNA-CH/github-actions/validate-branch-name-on-pr@main
 ```
 
 ## 💡 Example Workflow
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate branches name
-        uses: ProductDNA-CH/github-actions/validate-branch-name-on-pr@master
+        uses: ProductDNA-CH/github-actions/validate-branch-name-on-pr@main
 ```
 
 ## 📝 How it works

--- a/validate-pr-name/README.md
+++ b/validate-pr-name/README.md
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR name
-        uses: ProductDNA-CH/github-actions/validate-pr-name@master
+        uses: ProductDNA-CH/github-actions/validate-pr-name@main
         with:
           scopes: respect-code,respect-code-e2e,respect-saas,respect-saas-e2e,testbed,testbed-e2e,ui,api,core
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Part of Vanta branch protection migration (CORE-5345).

Updates @master refs and /tree/master URLs to @main / /tree/main
in workflow YAMLs and markdown documentation after github-actions
and devops repos were renamed master -> main.