### PR TITLE
feat: clickup-status-sync composite action

### DIFF
--- a/.github/workflows/test-clickup-status-sync.yml
+++ b/.github/workflows/test-clickup-status-sync.yml
@@ -1,0 +1,12 @@
+name: Test clickup-status-sync
+on:
+  pull_request:
+    paths: [clickup-status-sync/**]
+permissions: {}
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: sudo apt-get update && sudo apt-get install -y bats
+      - run: bats clickup-status-sync/tests/sync.bats

--- a/clickup-status-sync/README.md
+++ b/clickup-status-sync/README.md
@@ -47,7 +47,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: ProductDNA-CH/github-actions/clickup-status-sync@v1
+      - uses: ProductDNA-CH/github-actions/clickup-status-sync@clickup-status-sync/v1
         with:
           clickup-token: ${{ secrets.CLICKUP_API_TOKEN }}
 ```

--- a/clickup-status-sync/README.md
+++ b/clickup-status-sync/README.md
@@ -1,0 +1,120 @@
+# ClickUp Status Sync
+
+A GitHub composite action that moves a ClickUp task to the right status when a branch
+is created or a pull request is opened/merged — driven entirely from GitHub, with **no
+native ClickUp automations**.
+
+## Why this exists
+
+ClickUp's native "GitHub Automations" must be created **one per repository × per transition**
+in the UI, and each one is bound to **a single user's personal GitHub OAuth grant**. When that
+user's token is revoked or they leave, the automation silently fails and ClickUp disables it
+(error `AUTO_951 - GitHub token is invalid ...`). That model produced ~19 hand-duplicated rules
+coupled to one person's account.
+
+This action replaces all of them with **one versioned definition** consumed by a ~12-line workflow
+in each repo, authenticated by **one bot ClickUp token** stored as a GitHub org secret — decoupled
+from any individual.
+
+## Status mapping
+
+| GitHub event | Detail | `base` branch | → ClickUp status |
+|---|---|---|---|
+| `create` (branch) | branch created referencing a task | — | **in development** |
+| `pull_request` | `opened` / `ready_for_review` / `reopened` | `develop` | **in review** |
+| `pull_request` | `opened` / `ready_for_review` / `reopened` | `main` | **demo done** |
+| `pull_request` | `closed` + merged | `develop` | **dev done** |
+| `pull_request` | `closed` + merged | `main` | **shipped** |
+| `pull_request` | `closed`, not merged | — | no-op |
+| `create` (tag) | — | — | no-op |
+
+The task ID is extracted from the branch name (head branch for PRs) with the regex
+`<id-prefix>-[0-9]+` (default prefix `CORE`); all matches are deduplicated and updated.
+ClickUp matches the `status` field **case-insensitively**.
+
+## Usage
+
+In each consumer repo, add `.github/workflows/clickup-status-sync.yml`:
+
+```yaml
+name: ClickUp status sync
+on:
+  create:
+  pull_request:
+    types: [opened, ready_for_review, reopened, closed]
+permissions: {}
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ProductDNA-CH/github-actions/clickup-status-sync@v1
+        with:
+          clickup-token: ${{ secrets.CLICKUP_API_TOKEN }}
+```
+
+No `checkout` is needed — the action only reads the event payload, so it needs **no GitHub
+permissions** (`permissions: {}`).
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `clickup-token` | **yes** | — | ClickUp API token (`pk_...`) of the bot user |
+| `clickup-team-id` | no | `90151502952` | ClickUp workspace/team id (for `custom_task_ids`) |
+| `dev-branch` | no | `develop` | Branch that maps to *in review* / *dev done* |
+| `prod-branch` | no | `main` | Branch that maps to *demo done* / *shipped* |
+| `id-prefix` | no | `CORE` | Custom task id prefix |
+| `status-in-dev` | no | `in development` | Status set when a branch is created |
+| `status-in-review` | no | `in review` | Status set when a PR opens to `dev-branch` |
+| `status-dev-done` | no | `dev done` | Status set when a PR merges to `dev-branch` |
+| `status-demo-done` | no | `demo done` | Status set when a PR opens to `prod-branch` |
+| `status-shipped` | no | `shipped` | Status set when a PR merges to `prod-branch` |
+
+## Prerequisites (one-time, by an org/workspace admin)
+
+1. **Bot ClickUp user.** ClickUp has no native service account — create a dedicated **Member**
+   (e.g. `bot-devops@productdna.com`) with edit rights on the target space, so the sync is not
+   coupled to any person.
+2. **API token.** Logged in as the bot: avatar → `Settings` → `Apps` → `API Token` → `Generate`
+   (a `pk_...` token).
+3. **Verify the token and read the exact status names** of your list:
+
+   ```bash
+   curl -s -H "Authorization: pk_XXXX" \
+     "https://api.clickup.com/api/v2/list/<LIST_ID>" | jq '.statuses[].status'
+   ```
+
+4. **Org secret** scoped to the consumer repos:
+
+   ```bash
+   gh secret set CLICKUP_API_TOKEN --org ProductDNA-CH \
+     --visibility selected \
+     --repos frontend,backend-rss,backend-rsc,core-oauth
+   ```
+
+## Behavior & guarantees
+
+- **Never blocks a workflow.** The action always exits `0`. On a missing task ID or a ClickUp API
+  error it emits a `::warning::`; on success a `::notice::`.
+- **Idempotent.** Re-applying the same status is a no-op on ClickUp's side.
+- **No anti-regression guard.** Opening a new `develop` PR on an already-shipped task moves it back
+  to *in review* — this matches the original native behavior. (Could be added later if desired.)
+
+## Local testing
+
+The logic lives in a pure, env-driven `sync.sh` (no GitHub API calls), unit-tested with
+[bats-core](https://github.com/bats-core/bats-core):
+
+```bash
+brew install bats-core
+bats clickup-status-sync/tests/sync.bats
+```
+
+Set `DRY_RUN=1` to print the intended updates without calling ClickUp:
+
+```bash
+DRY_RUN=1 EVENT_NAME=pull_request PR_ACTION=opened \
+  PR_BASE_REF=develop PR_HEAD_REF=feat/CORE-100-x \
+  ./clickup-status-sync/sync.sh
+# ::notice::WOULD update CORE-100 -> in review
+```

--- a/clickup-status-sync/action.yaml
+++ b/clickup-status-sync/action.yaml
@@ -1,0 +1,68 @@
+name: ClickUp Status Sync
+description: Map GitHub branch/PR events to ClickUp task statuses (no native ClickUp automations).
+
+inputs:
+  clickup-token:
+    description: ClickUp API token (pk_...) of the bot user.
+    required: true
+  clickup-team-id:
+    description: ClickUp workspace/team id (for custom_task_ids).
+    required: false
+    default: "90151502952"
+  dev-branch:
+    description: Branch that maps to in review / dev done.
+    required: false
+    default: develop
+  prod-branch:
+    description: Branch that maps to demo done / shipped.
+    required: false
+    default: main
+  id-prefix:
+    description: Custom task id prefix.
+    required: false
+    default: CORE
+  status-in-dev:
+    description: ClickUp status when a branch is created.
+    required: false
+    default: in development
+  status-in-review:
+    description: ClickUp status when a PR is opened to the dev branch.
+    required: false
+    default: in review
+  status-dev-done:
+    description: ClickUp status when a PR is merged to the dev branch.
+    required: false
+    default: dev done
+  status-demo-done:
+    description: ClickUp status when a PR is opened to the prod branch.
+    required: false
+    default: demo done
+  status-shipped:
+    description: ClickUp status when a PR is merged to the prod branch.
+    required: false
+    default: shipped
+
+runs:
+  using: composite
+  steps:
+    - name: Sync ClickUp status
+      shell: bash
+      env:
+        CLICKUP_TOKEN: ${{ inputs.clickup-token }}
+        CLICKUP_TEAM_ID: ${{ inputs.clickup-team-id }}
+        DEV_BRANCH: ${{ inputs.dev-branch }}
+        PROD_BRANCH: ${{ inputs.prod-branch }}
+        ID_PREFIX: ${{ inputs.id-prefix }}
+        STATUS_IN_DEV: ${{ inputs.status-in-dev }}
+        STATUS_IN_REVIEW: ${{ inputs.status-in-review }}
+        STATUS_DEV_DONE: ${{ inputs.status-dev-done }}
+        STATUS_DEMO_DONE: ${{ inputs.status-demo-done }}
+        STATUS_SHIPPED: ${{ inputs.status-shipped }}
+        EVENT_NAME: ${{ github.event_name }}
+        REF_TYPE: ${{ github.event.ref_type }}
+        CREATED_REF: ${{ github.event.ref }}
+        PR_ACTION: ${{ github.event.action }}
+        PR_MERGED: ${{ github.event.pull_request.merged }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: ${{ github.action_path }}/sync.sh

--- a/clickup-status-sync/sync.sh
+++ b/clickup-status-sync/sync.sh
@@ -66,8 +66,47 @@ resolve_status() {
   esac
 }
 
-# Filled in T4.
-main() { :; }
+# Update a single ClickUp task's status. Honours DRY_RUN. Never aborts the run.
+update_task() {
+  local id="$1" status="$2"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    note "WOULD update ${id} -> ${status}"
+    return 0
+  fi
+  local code body
+  body=$(curl -sS -w '\n%{http_code}' -X PUT \
+    -H "Authorization: ${CLICKUP_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "https://api.clickup.com/api/v2/task/${id}?custom_task_ids=true&team_id=${CLICKUP_TEAM_ID}" \
+    -d "{\"status\":\"${status}\"}") || { warn "curl failed for ${id}"; return 0; }
+  code=$(tail -n1 <<<"$body")
+  if [[ "$code" == "200" ]]; then
+    note "updated ${id} -> ${status}"
+  else
+    warn "ClickUp API ${code} for ${id}: $(sed '$d' <<<"$body" | tr -d '\n' | cut -c1-200)"
+  fi
+}
+
+main() {
+  local status ref ids found=0
+  status="$(resolve_status)"
+  if [[ -z "$status" ]]; then
+    note "no status transition for event=${EVENT_NAME} action=${PR_ACTION:-} base=${PR_BASE_REF:-}; nothing to do"
+    return 0
+  fi
+  ref="$(resolve_ref)"
+  ids="$(extract_ids "$ref")"
+  if [[ -z "$ids" ]]; then
+    warn "target status '${status}' but no ${ID_PREFIX}-NNN id found in ref '${ref}'"
+    return 0
+  fi
+  while IFS= read -r id; do
+    [[ -n "$id" ]] || continue
+    update_task "$id" "$status"
+    found=1
+  done <<<"$ids"
+  [[ "$found" == 1 ]] || warn "no task updated"
+}
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main

--- a/clickup-status-sync/sync.sh
+++ b/clickup-status-sync/sync.sh
@@ -28,7 +28,13 @@ PR_BASE_REF="${PR_BASE_REF:-}"
 note() { echo "::notice::$*"; }
 warn() { echo "::warning::$*"; }
 
-# Functions filled in T2/T3/T4.
+# Print unique task IDs (one per line) found in $1.
+extract_ids() {
+  local text="$1"
+  grep -oE "${ID_PREFIX}-[0-9]+" <<<"$text" | awk '!seen[$0]++'
+}
+
+# Filled in T3/T4.
 main() { :; }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/clickup-status-sync/sync.sh
+++ b/clickup-status-sync/sync.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# clickup-status-sync core logic. Pure: reads env vars, no GitHub API calls.
+# Always exits 0 — never blocks a workflow.
+set -uo pipefail
+
+# --- Inputs (with defaults) ---
+CLICKUP_TOKEN="${CLICKUP_TOKEN:-}"
+DEV_BRANCH="${DEV_BRANCH:-develop}"
+PROD_BRANCH="${PROD_BRANCH:-main}"
+ID_PREFIX="${ID_PREFIX:-CORE}"
+CLICKUP_TEAM_ID="${CLICKUP_TEAM_ID:-90151502952}"
+STATUS_IN_DEV="${STATUS_IN_DEV:-in development}"
+STATUS_IN_REVIEW="${STATUS_IN_REVIEW:-in review}"
+STATUS_DEV_DONE="${STATUS_DEV_DONE:-dev done}"
+STATUS_DEMO_DONE="${STATUS_DEMO_DONE:-demo done}"
+STATUS_SHIPPED="${STATUS_SHIPPED:-shipped}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# --- GitHub event context (mapped by action.yaml) ---
+EVENT_NAME="${EVENT_NAME:-}"
+REF_TYPE="${REF_TYPE:-}"
+CREATED_REF="${CREATED_REF:-}"
+PR_ACTION="${PR_ACTION:-}"
+PR_MERGED="${PR_MERGED:-}"
+PR_HEAD_REF="${PR_HEAD_REF:-}"
+PR_BASE_REF="${PR_BASE_REF:-}"
+
+note() { echo "::notice::$*"; }
+warn() { echo "::warning::$*"; }
+
+# Functions filled in T2/T3/T4.
+main() { :; }
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
+  exit 0
+fi

--- a/clickup-status-sync/sync.sh
+++ b/clickup-status-sync/sync.sh
@@ -34,7 +34,39 @@ extract_ids() {
   grep -oE "${ID_PREFIX}-[0-9]+" <<<"$text" | awk '!seen[$0]++'
 }
 
-# Filled in T3/T4.
+# Print the branch ref carrying the task id, depending on the event.
+resolve_ref() {
+  case "$EVENT_NAME" in
+    create)       printf '%s' "$CREATED_REF" ;;
+    pull_request) printf '%s' "$PR_HEAD_REF" ;;
+  esac
+}
+
+# Print the target ClickUp status for this event, or nothing for a no-op.
+resolve_status() {
+  case "$EVENT_NAME" in
+    create)
+      [[ "$REF_TYPE" == "branch" ]] && printf '%s' "$STATUS_IN_DEV"
+      ;;
+    pull_request)
+      case "$PR_ACTION" in
+        opened|reopened|ready_for_review)
+          if   [[ "$PR_BASE_REF" == "$DEV_BRANCH"  ]]; then printf '%s' "$STATUS_IN_REVIEW"
+          elif [[ "$PR_BASE_REF" == "$PROD_BRANCH" ]]; then printf '%s' "$STATUS_DEMO_DONE"
+          fi
+          ;;
+        closed)
+          [[ "$PR_MERGED" == "true" ]] || return 0
+          if   [[ "$PR_BASE_REF" == "$DEV_BRANCH"  ]]; then printf '%s' "$STATUS_DEV_DONE"
+          elif [[ "$PR_BASE_REF" == "$PROD_BRANCH" ]]; then printf '%s' "$STATUS_SHIPPED"
+          fi
+          ;;
+      esac
+      ;;
+  esac
+}
+
+# Filled in T4.
 main() { :; }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/clickup-status-sync/tests/sync.bats
+++ b/clickup-status-sync/tests/sync.bats
@@ -1,0 +1,3 @@
+#!/usr/bin/env bats
+# Run: bats clickup-status-sync/tests/sync.bats
+SCRIPT="${BATS_TEST_DIRNAME}/../sync.sh"

--- a/clickup-status-sync/tests/sync.bats
+++ b/clickup-status-sync/tests/sync.bats
@@ -69,3 +69,29 @@ rs() { # helper: run resolve_status with given env
   run env EVENT_NAME=pull_request PR_HEAD_REF=fix/CORE-8 bash -c 'source "'"$SCRIPT"'" 2>/dev/null; resolve_ref'
   [ "$output" = "fix/CORE-8" ]
 }
+
+# --- Task 4: end-to-end (dry-run) ---
+
+@test "e2e: PR opened to develop dry-runs the right calls" {
+  run env DRY_RUN=1 EVENT_NAME=pull_request PR_ACTION=opened \
+      PR_BASE_REF=develop PR_HEAD_REF=feat/CORE-100-x \
+      DEV_BRANCH=develop PROD_BRANCH=main ID_PREFIX=CORE \
+      "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WOULD update CORE-100 -> in review"* ]]
+}
+
+@test "e2e: no task id -> warning, exit 0" {
+  run env DRY_RUN=1 EVENT_NAME=pull_request PR_ACTION=opened \
+      PR_BASE_REF=develop PR_HEAD_REF=develop "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::warning::"* ]]
+  [[ "$output" == *"no "* ]]
+}
+
+@test "e2e: no-op event exits 0 quietly" {
+  run env DRY_RUN=1 EVENT_NAME=pull_request PR_ACTION=closed \
+      PR_MERGED=false PR_HEAD_REF=feat/CORE-1 "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"WOULD update"* ]]
+}

--- a/clickup-status-sync/tests/sync.bats
+++ b/clickup-status-sync/tests/sync.bats
@@ -1,3 +1,23 @@
 #!/usr/bin/env bats
 # Run: bats clickup-status-sync/tests/sync.bats
 SCRIPT="${BATS_TEST_DIRNAME}/../sync.sh"
+
+# --- Task 2: extract_ids ---
+
+@test "extracts a single CORE id from a branch" {
+  run env ID_PREFIX=CORE bash -c 'source "'"$SCRIPT"'" 2>/dev/null; extract_ids "feat/CORE-3470-fix-thing"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "CORE-3470" ]
+}
+
+@test "extracts and dedupes multiple ids" {
+  run env ID_PREFIX=CORE bash -c 'source "'"$SCRIPT"'" 2>/dev/null; extract_ids "CORE-1_CORE-2_CORE-1"'
+  printf '%s\n' "$output" | grep -qx "CORE-1"
+  printf '%s\n' "$output" | grep -qx "CORE-2"
+  [ "$(printf '%s\n' "$output" | grep -c CORE-1)" -eq 1 ]
+}
+
+@test "returns nothing when no id present" {
+  run env ID_PREFIX=CORE bash -c 'source "'"$SCRIPT"'" 2>/dev/null; extract_ids "develop"'
+  [ -z "$output" ]
+}

--- a/clickup-status-sync/tests/sync.bats
+++ b/clickup-status-sync/tests/sync.bats
@@ -21,3 +21,51 @@ SCRIPT="${BATS_TEST_DIRNAME}/../sync.sh"
   run env ID_PREFIX=CORE bash -c 'source "'"$SCRIPT"'" 2>/dev/null; extract_ids "develop"'
   [ -z "$output" ]
 }
+
+# --- Task 3: resolve_status / resolve_ref ---
+
+rs() { # helper: run resolve_status with given env
+  run env "$@" bash -c 'source "'"$SCRIPT"'" 2>/dev/null; resolve_status'
+}
+
+@test "create branch -> in development" {
+  rs EVENT_NAME=create REF_TYPE=branch
+  [ "$output" = "in development" ]
+}
+@test "create tag -> no-op (empty)" {
+  rs EVENT_NAME=create REF_TYPE=tag
+  [ -z "$output" ]
+}
+@test "PR opened to develop -> in review" {
+  rs EVENT_NAME=pull_request PR_ACTION=opened PR_BASE_REF=develop DEV_BRANCH=develop PROD_BRANCH=main
+  [ "$output" = "in review" ]
+}
+@test "PR ready_for_review to main -> demo done" {
+  rs EVENT_NAME=pull_request PR_ACTION=ready_for_review PR_BASE_REF=main DEV_BRANCH=develop PROD_BRANCH=main
+  [ "$output" = "demo done" ]
+}
+@test "PR merged to develop -> dev done" {
+  rs EVENT_NAME=pull_request PR_ACTION=closed PR_MERGED=true PR_BASE_REF=develop DEV_BRANCH=develop PROD_BRANCH=main
+  [ "$output" = "dev done" ]
+}
+@test "PR merged to main -> shipped" {
+  rs EVENT_NAME=pull_request PR_ACTION=closed PR_MERGED=true PR_BASE_REF=main DEV_BRANCH=develop PROD_BRANCH=main
+  [ "$output" = "shipped" ]
+}
+@test "PR closed unmerged -> no-op" {
+  rs EVENT_NAME=pull_request PR_ACTION=closed PR_MERGED=false PR_BASE_REF=develop
+  [ -z "$output" ]
+}
+@test "PR opened to unrelated base -> no-op" {
+  rs EVENT_NAME=pull_request PR_ACTION=opened PR_BASE_REF=release/x DEV_BRANCH=develop PROD_BRANCH=main
+  [ -z "$output" ]
+}
+
+@test "resolve_ref returns created ref for create" {
+  run env EVENT_NAME=create CREATED_REF=feat/CORE-9 bash -c 'source "'"$SCRIPT"'" 2>/dev/null; resolve_ref'
+  [ "$output" = "feat/CORE-9" ]
+}
+@test "resolve_ref returns head ref for PR" {
+  run env EVENT_NAME=pull_request PR_HEAD_REF=fix/CORE-8 bash -c 'source "'"$SCRIPT"'" 2>/dev/null; resolve_ref'
+  [ "$output" = "fix/CORE-8" ]
+}


### PR DESCRIPTION
## What

A composite action `clickup-status-sync` mapping GitHub branch/PR events to ClickUp task statuses, replacing the ~19 hand-duplicated native ClickUp GitHub automations (each coupled to a personal GitHub account, prone to `AUTO_951` token death).

## Mapping

| Event | base | → ClickUp status |
|---|---|---|
| branch created | — | in development |
| PR opened | develop | in review |
| PR merged | develop | dev done |
| PR opened | main | demo done |
| PR merged | main | shipped |

## Design

- Pure env-driven `sync.sh` (no GitHub API calls, `permissions: {}`), unit-tested with bats (16 tests).
- Non-blocking: always exits 0, warnings only.
- Authenticated by one bot ClickUp token passed as input from an org secret.

See `clickup-status-sync/README.md` for full docs, inputs and prerequisites.

## Consumption (after merge + tag `clickup-status-sync/v1`)

```yaml
- uses: ProductDNA-CH/github-actions/clickup-status-sync@clickup-status-sync/v1
  with:
    clickup-token: ${{ secrets.CLICKUP_API_TOKEN }}
```