### PR TITLE
ci: allow dependabot/ branch prefix in branch-name validator

### DIFF
--- a/validate-branch-name-on-pr/action.yaml
+++ b/validate-branch-name-on-pr/action.yaml
@@ -30,9 +30,9 @@ runs:
 
         case "$BASE" in
           develop)
-            ALLOWED="feat/, fix/, docs/, style/, refactor/, perf/, test/, build/, ci/, chore/, revert/"
+            ALLOWED="feat/, fix/, docs/, style/, refactor/, perf/, test/, build/, ci/, chore/, revert/, dependabot/"
             case "$PREFIX" in
-              feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)
+              feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|dependabot)
                 echo "✅ Valid prefix '$PREFIX' for target '$BASE'"
                 ;;
               *)
@@ -47,9 +47,9 @@ runs:
             esac
             ;;
           main)
-            ALLOWED="release/, hotfix/"
+            ALLOWED="release/, hotfix/, dependabot/"
             case "$PREFIX" in
-              release|hotfix)
+              release|hotfix|dependabot)
                 echo "✅ Valid prefix '$PREFIX' for target '$BASE'"
                 ;;
               *)


### PR DESCRIPTION
## Why

Prerequisite for rolling out **Dependabot for GitHub Actions** across the org. Dependabot opens PRs from branches named `dependabot/github_actions/...`. The shared `validate-branch-name-on-pr` action currently rejects any prefix other than `feat/fix/.../chore/revert` (target `develop`) or `release/hotfix` (target `main`), so **every Dependabot PR would fail the check**.

## What

Add `dependabot` to the allowed prefixes for both target branches:
- `develop` target: `feat/, fix/, docs/, style/, refactor/, perf/, test/, build/, ci/, chore/, revert/, dependabot/`
- `main` target: `release/, hotfix/, dependabot/`

No behaviour change for existing prefixes. PR-name validation is left untouched: Dependabot will be configured with `commit-message.prefix: "chore"`, so its PR titles (`chore: bump X from Y to Z`) already satisfy `validate-pr-name` (the scope group is optional in its regex).

## Scope

Single-file change to the shared composite action. Consumers pin `@main`, so the fix propagates to all repos on merge.