### PR TITLE
ci: add Dependabot for GitHub Actions (incl. composite action dirs)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Dependabot configuration — keeps GitHub Actions references up to date.
+# Opens a single grouped PR on a monthly cadence. References use floating major
+# tags (e.g. actions/checkout@v6), so Dependabot bumps to the latest major tag.
+# This repo hosts composite actions in top-level subdirectories, so `directories`
+# covers both the workflows ("/") and every composite action dir ("/*").
+# Note: references pinned to a branch (e.g. @main) are NOT tracked by Dependabot.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/*"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10

--- a/python-lib-test/action.yaml
+++ b/python-lib-test/action.yaml
@@ -16,7 +16,7 @@ runs:
     - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.2.0
       with:
         version: ${{ inputs.uv_version }}
         python-version: ${{ inputs.python_version }}


### PR DESCRIPTION
## Why

Final repo of the org-wide Dependabot for GitHub Actions rollout (validated on devops + backend-rss). This repo hosts the org's shared composite actions, which live in **top-level subdirectories** (`python-lib-test/`, `validate-*/`, `clickup-status-sync/`, …) — those are not covered by a plain `directory: "/"`.

## What

- `.github/dependabot.yml` with `directories: ["/", "/*"]` so Dependabot scans both the workflows (`/`) and every composite-action subdirectory (`/*`).
- Pins `astral-sh/setup-uv@v6 → @v8.2.0` in `python-lib-test/action.yaml` (no floating `v8` tag).

Dependabot will then bump the actions referenced by the composite actions and workflows (e.g. `actions/checkout@v5 → v6`) to their latest floating major tags.